### PR TITLE
fix intersection bug

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -905,7 +905,6 @@ new function() { // Injection scope for various item event handlers
         // See if we can cache these bounds. We only cache the bounds
         // transformed with the internally stored _matrix, (the default if no
         // matrix is passed).
-        matrix = matrix && matrix._orNullIfIdentity();
         // Do not transform by the internal matrix for internal, untransformed
         // bounds.
         var internal = options.internal && !noInternal,


### PR DESCRIPTION
Fix intersection bug under the following condition.
- multiplying parent and child matrix results in identity matrix
- applyMatrix is false

### Description


#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Relates to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the ESLint and Prettier rules (`yarn eslint` passes
      and `yarn prettier` has been applied)
