### PR TITLE
fix Item#intersects() & PathItm#getIntersections()

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -1219,6 +1219,15 @@ new function() { // Injection scope for various item event handlers
     },
 
     /**
+     * The item's transformation matrix in relation to the given item's
+     * coordinate space. Note that the view's transformations resulting from
+     * zooming and panning are not factored in.
+     */
+    getMatrixTo: function(item) {
+        return item.getGlobalMatrix().invert().append(this.getGlobalMatrix(true))
+    },
+
+    /**
      * The item's global matrix in relation to the view coordinate space. This
      * means that the view's transformations resulting from zooming and panning
      * are factored in.
@@ -1797,6 +1806,9 @@ new function() { // Injection scope for various item event handlers
     intersects: function(item, _matrix) {
         if (!(item instanceof Item))
             return false;
+        if (! this._applyMatrix && _matrix == null) {
+            _matrix = this._parent.getGlobalMatrix().invert().append(item.getGlobalMatrix(true))._orNullIfIdentity()
+        }
         // Tell getIntersections() to return as soon as some intersections are
         // found, because all we care for here is there are some or none:
         return this._asPathItem().getIntersections(item._asPathItem(), null,
@@ -3577,6 +3589,11 @@ new function() { // Injection scope for hit-test functions shared with project
      */
     localToParent: function(/* point */) {
         return this._matrix._transformPoint(Point.read(arguments));
+    },
+
+    localToOther: function(item, point) {
+        let matrix = this.getMatrixTo(item)
+        return matrix._transformPoint(Point.read([point]));
     },
 
     /**

--- a/src/path/PathItem.js
+++ b/src/path/PathItem.js
@@ -324,10 +324,12 @@ var PathItem = Item.extend(/** @lends PathItem# */{
         // intersections.
         // NOTE: The hidden argument _matrix is used internally to override the
         // passed path's transformation matrix.
+        if (! this._applyMatrix && _matrix == null) {
+            _matrix = this._parent.getGlobalMatrix().invert().append(path.getGlobalMatrix(true))._orNullIfIdentity()
+        }
         var self = this === path || !path, // self-intersections?
             matrix1 = this._matrix._orNullIfIdentity(),
-            matrix2 = self ? matrix1
-                : (_matrix || path._matrix)._orNullIfIdentity();
+            matrix2 = self ? matrix1 : _matrix
         // First check the bounds of the two paths. If they don't intersect,
         // we don't need to iterate through their curves.
         return self || this.getBounds(matrix1).intersects(


### PR DESCRIPTION
to work even if each item's coordinations are different when applyMatrix: false

### Description


#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Relates to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the ESLint and Prettier rules (`yarn eslint` passes
      and `yarn prettier` has been applied)
