### PR TITLE
fix intersection bug

### DIFF
--- a/src/item/Item.js
+++ b/src/item/Item.js
@@ -943,7 +943,6 @@ new function() { // Injection scope for various item event handlers
         // See if we can cache these bounds. We only cache the bounds
         // transformed with the internally stored _matrix, (the default if no
         // matrix is passed).
-        matrix = matrix && matrix._orNullIfIdentity();
         // Do not transform by the internal matrix for internal, untransformed
         // bounds.
         var internal = options.internal && !noInternal,
@@ -1869,6 +1868,9 @@ new function() { // Injection scope for various item event handlers
     intersects: function(item, _matrix) {
         if (!(item instanceof Item))
             return false;
+        if (! this._applyMatrix && _matrix == null) {
+            _matrix = item.getMatrixTo(this._parent)._orNullIfIdentity();
+        }
         // Tell getIntersections() to return as soon as some intersections are
         // found, because all we care for here is there are some or none:
         return this._asPathItem().getIntersections(item._asPathItem(), null,

--- a/src/path/PathItem.js
+++ b/src/path/PathItem.js
@@ -324,10 +324,12 @@ var PathItem = Item.extend(/** @lends PathItem# */{
         // intersections.
         // NOTE: The hidden argument _matrix is used internally to override the
         // passed path's transformation matrix.
+        if (! this._applyMatrix && _matrix == null) {
+            _matrix = path.getMatrixTo(this._parent)._orNullIfIdentity();
+        }
         var self = this === path || !path, // self-intersections?
             matrix1 = this._matrix._orNullIfIdentity(),
-            matrix2 = self ? matrix1
-                : (_matrix || path._matrix)._orNullIfIdentity();
+            matrix2 = self ? matrix1 : _matrix;
         // First check the bounds of the two paths. If they don't intersect,
         // we don't need to iterate through their curves.
         return self || this.getBounds(matrix1).intersects(


### PR DESCRIPTION
Fix intersection bug under the following condition.
- multiplying parent and child matrix results in identity matrix
- applyMatrix is false

### Description


#### Related issues

<!--
Please list related issues and discussion by using the following syntax:

- Relates to #49
  (to reference issues in the Objection.js repository)
- Relates to https://github.com/tgriesser/knex/issues/100
  (to reference issues in a related repository)
-->

- Relates to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
  https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the JSHint rules (`npm run jshint` passes)
